### PR TITLE
Vulnerabilities for version-exporter

### DIFF
--- a/cmd/qubership-version-exporter/main.go
+++ b/cmd/qubership-version-exporter/main.go
@@ -25,15 +25,16 @@ import (
 	"time"
 
 	"qubership-version-exporter/collector"
+
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	versionCollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
 	"github.com/prometheus/common/version"
-	versionCollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/exporter-toolkit/web"
 	webflag "github.com/prometheus/exporter-toolkit/web/kingpinflag"
 	"k8s.io/client-go/kubernetes"
@@ -187,6 +188,7 @@ func main() {
 func healthChecker() http.Handler {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("OK"))
 		},
 	)
@@ -195,6 +197,7 @@ func healthChecker() http.Handler {
 func readinessChecker() http.Handler {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("OK"))
 		})
 }

--- a/collector/http_collector.go
+++ b/collector/http_collector.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	collectorModel "qubership-version-exporter/model/http"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
@@ -456,9 +457,9 @@ func (httpCollector *HttpCollector) parseTextResponse(responseText string, metri
 				_ = level.Error(httpCollector.logger).Log("msg",
 					"Invalid configuration. Response type is: 'text/plain'. Regexp can't be empty in the configuration")
 				metricLabels[m] = append(metricLabels[m], make([]Labels, 1)...)
-				length += 1
 				metricLabels[m][length].Name = append(metricLabels[m][length].Name, string(*label.name))
 				metricLabels[m][length].Value = append(metricLabels[m][length].Value, "")
+				length++
 			}
 		}
 	}


### PR DESCRIPTION
fixed vulnerabilities: 
set header for responses of health/readiness checkers; 
set correct index for structure of metricsLabels in case of a label doesn't have a RegExp