### PR TITLE
fix: restore the logic to read cli flags

### DIFF
--- a/cmd/qubership-version-exporter/main.go
+++ b/cmd/qubership-version-exporter/main.go
@@ -63,6 +63,11 @@ func init() {
 }
 
 func main() {
+	// Read CLI flags
+	kingpin.Version(version.Print("version_exporter"))
+	kingpin.CommandLine.UsageWriter(os.Stdout)
+	kingpin.Parse()
+
 	// Initialize logger
 	logLevel := os.Getenv("LOG_LEVEL")
 	if logLevel == "" {
@@ -183,7 +188,7 @@ func main() {
 	if !errors.Is(exit, http.ErrServerClosed) {
 		logger.Error("Failed to start application", "error", exit)
 	}
-	logger.Info("Server is shut down")
+	logger.Info("Server is shutdown")
 }
 
 func healthChecker() http.Handler {


### PR DESCRIPTION
# What does this MR do?

During the start of this component fails with the error:

```bash
{"time":"2025-05-19T15:25:29.840208089Z","level":"INFO","msg":"Starting qubership_version_exporter","version":"(version=, branch=, revision=unknown)"}
{"time":"2025-05-19T15:25:29.840306286Z","level":"INFO","msg":"Build context","context":"(go=go1.24.2, platform=linux/arm64, user=, date=, tags=unknown)"}
{"time":"2025-05-19T15:25:29.840733349Z","level":"DEBUG","msg":"trying to read config: "}
{"time":"2025-05-19T15:25:29.840749751Z","level":"ERROR","msg":"failed to read config file","error":"open : no such file or directory"}
{"time":"2025-05-19T15:25:29.840757947Z","level":"ERROR","msg":"Initialization failed","error":"open : no such file or directory"}
```

## Root cause

In the latest PR was broken the logic to read CLI flags and nobody found it.

## Solution

Added lost call of `kingping.Parse()` in the `main.go`.