### PR TITLE
chore: update dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,7 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "monthly"
+    interval: "weekly"
   commit-message:
     prefix: chore
     prefix-development: chore
@@ -19,7 +19,7 @@ updates:
   directories:
   - "/"
   schedule:
-    interval: "monthly"
+    interval: "weekly"
   commit-message:
     prefix: chore
     prefix-development: chore
@@ -32,8 +32,12 @@ updates:
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
-    interval: "monthly"
+    interval: "weekly"
   open-pull-requests-limit: 20
+  commit-message:
+    prefix: chore
+    prefix-development: chore
+    include: scope
   groups:
     k8s.io:
       patterns:


### PR DESCRIPTION
# What does this PR do?

It needs to update DependaBot settings (before we fully migrate to renovation-bot) and to:
* run it more frequently, each week
