### PR TITLE
chore(go): add toolchain directive to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/Netcracker/qubership-version-exporter
 
 go 1.26.0
+toolchain go1.26.4
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
Adds an explicit toolchain directive to go.mod that matches the existing go version (go1.26.0). See Go toolchain management docs: https://go.dev/doc/toolchain