### PR TITLE
fix(build): retain explicit Alpine builder version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine@sha256:648921a68c7179241dd09daf8000fbfddc9e5ea9c1a24e7d0fe05b259dff2b5c AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.24@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## Why

[PR #229](https://github.com/Netcracker/qubership-version-exporter/pull/229) replaced an explicit Alpine version with the floating `-alpine` alias and pinned its current i386 manifest digest. The builder must use a multiarch image and expose Alpine version changes in dependency diffs.

## What

- Use `golang:1.26.6-alpine3.24` with its multiarch digest.
- Keep the builder Alpine version aligned with the Alpine 3.24 runtime image.
- Link the shared Renovate fix in [renovate-config#41](https://github.com/Netcracker/renovate-config/pull/41), which will update explicit Go and Alpine builder versions together.

## How to verify

- Run `docker build --check -f Dockerfile .`.
- Run the existing Go tests and image build.
